### PR TITLE
add MCP option to Ask Sona widget

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -19,7 +19,7 @@
     data-button-width="5.5rem"
     data-modal-disclaimer="Ask Sona AI learns from our help resources and is always improving. Please verify important details before use."
     data-modal-disclaimer-text-color="black"
-    data-modal-header-bg-color="#7034EE"
+    data-modal-header-bg-color="#8056FF"
     data-modal-header-padding="10px"
     data-modal-image-height="38"
     data-modal-image-width="35"
@@ -32,6 +32,8 @@
     data-project-name="Sonatype"
     data-user-analytics-fingerprint-enabled="true"
     data-website-id="8bee4e95-3b20-431a-874b-67212f459ccf"
+    data-mcp-enabled="true"
+    data-mcp-server-url="https://sonatype.mcp.kapa.ai"
     src="https://widget.kapa.ai/kapa-widget.bundle.js"
 ></script>
 


### PR DESCRIPTION
This change is for https://sonatype.atlassian.net/browse/SPRTINFRA-359 to add MCP option to the 'Ask Sona' widget currently available on the Sonatype Help site.
A screenshot of the change for [support.sonatype.com](http://support.sonatype.com/) is available in the mentioned JIRA and can also been seem on the [support.sonatype.com](http://support.sonatype.com/).